### PR TITLE
Feature/shib sp wayfless

### DIFF
--- a/rapidconnect/app/rapid_connect.rb
+++ b/rapidconnect/app/rapid_connect.rb
@@ -109,8 +109,7 @@ class RapidConnect < Sinatra::Base
   get '/login/:id' do |id|
     shibboleth_login_url = "/Shibboleth.sso/Login?target=/login/shibboleth/#{id}"
     if params[:entityID]
-      shibboleth_login_url = append_entity_id(shibboleth_login_url,
-                                              params[:entityID])
+      shibboleth_login_url = "#{shibboleth_login_url}&entityID=#{params[:entityID]}"
     end
     redirect shibboleth_login_url
   end
@@ -477,7 +476,7 @@ class RapidConnect < Sinatra::Base
 
     login_url = "/login/#{id}"
     if params[:entityID]
-      login_url = append_entity_id(login_url, params[:entityID])
+      login_url = "#{login_url}?entityID=#{params[:entityID]}"
     end
     redirect login_url
   end
@@ -590,9 +589,5 @@ class RapidConnect < Sinatra::Base
   ##
   def load_organisations
     JSON.parse(IO.read(settings.organisations))
-  end
-
-  def append_entity_id(url, entity_id)
-    "#{url}&entityID=#{entity_id}"
   end
 end

--- a/rapidconnect/app/rapid_connect.rb
+++ b/rapidconnect/app/rapid_connect.rb
@@ -108,6 +108,10 @@ class RapidConnect < Sinatra::Base
   ###
   get '/login/:id' do |id|
     shibboleth_login_url = "/Shibboleth.sso/Login?target=/login/shibboleth/#{id}"
+    if params[:entityID]
+      shibboleth_login_url = append_entity_id(shibboleth_login_url,
+                                              params[:entityID])
+    end
     redirect shibboleth_login_url
   end
 
@@ -470,7 +474,12 @@ class RapidConnect < Sinatra::Base
     id = SecureRandom.urlsafe_base64(24, false)
     session[:target] ||= {}
     session[:target][id] = request.url
-    redirect "/login/#{id}"
+
+    login_url = "/login/#{id}"
+    if params[:entityID]
+      login_url = append_entity_id(login_url, params[:entityID])
+    end
+    redirect login_url
   end
 
   def administrator?
@@ -581,5 +590,9 @@ class RapidConnect < Sinatra::Base
   ##
   def load_organisations
     JSON.parse(IO.read(settings.organisations))
+  end
+
+  def append_entity_id(url, entity_id)
+    url << "&entityID=#{entity_id}"
   end
 end

--- a/rapidconnect/app/rapid_connect.rb
+++ b/rapidconnect/app/rapid_connect.rb
@@ -593,6 +593,6 @@ class RapidConnect < Sinatra::Base
   end
 
   def append_entity_id(url, entity_id)
-    url << "&entityID=#{entity_id}"
+    "#{url}&entityID=#{entity_id}"
   end
 end

--- a/rapidconnect/spec/rapid_connect_spec.rb
+++ b/rapidconnect/spec/rapid_connect_spec.rb
@@ -644,7 +644,7 @@ describe RapidConnect do
         expect(last_response.location)
           .to start_with('http://example.org/login/')
         expect(last_response.location)
-          .to contain('&entityID=https://vho.aaf.edu.au/idp/shibboleth')
+          .to contain('?entityID=https://vho.aaf.edu.au/idp/shibboleth')
       end
     end
 

--- a/rapidconnect/spec/rapid_connect_spec.rb
+++ b/rapidconnect/spec/rapid_connect_spec.rb
@@ -93,6 +93,14 @@ describe RapidConnect do
       expect(last_response.location).to eq('http://example.org/Shibboleth.sso/Login?target=/login/shibboleth/1')
     end
 
+    it 'redirects to Shibboleth SP SSO with entityID' do
+      get '/login/1?entityID=https://vho.aaf.edu.au/idp/shibboleth'
+      expect(last_response).to be_redirect
+      expect(last_response.location).to eq('http://example.org/Shibboleth.sso' \
+         '/Login?target=/login/shibboleth' \
+         '/1&entityID=https://vho.aaf.edu.au/idp/shibboleth')
+    end
+
     it 'sends a 403 response if Shibboleth SP login response contains no session id' do
       get '/login/shibboleth/1'
       expect(last_response.status).to eq(403)
@@ -628,6 +636,15 @@ describe RapidConnect do
         expect(last_response).to be_redirect
         expect(last_response.location)
           .to start_with('http://example.org/login/')
+      end
+
+      it 'directs to login with entityID included' do
+        get '/jwt/xyz?entityID=https://vho.aaf.edu.au/idp/shibboleth'
+        expect(last_response).to be_redirect
+        expect(last_response.location)
+            .to start_with('http://example.org/login/')
+        expect(last_response.location)
+          .to contain('&entityID=https://vho.aaf.edu.au/idp/shibboleth')
       end
     end
 

--- a/rapidconnect/spec/rapid_connect_spec.rb
+++ b/rapidconnect/spec/rapid_connect_spec.rb
@@ -642,7 +642,7 @@ describe RapidConnect do
         get '/jwt/xyz?entityID=https://vho.aaf.edu.au/idp/shibboleth'
         expect(last_response).to be_redirect
         expect(last_response.location)
-            .to start_with('http://example.org/login/')
+          .to start_with('http://example.org/login/')
         expect(last_response.location)
           .to contain('&entityID=https://vho.aaf.edu.au/idp/shibboleth')
       end


### PR DESCRIPTION
Allow entityID to be forwarded for direct IdP auth.

This is supported in Shibboleth SP as a WAYF-less session initiator
as described in #24.