### PR TITLE
Fixed LoadError when attempting to run CLI

### DIFF
--- a/rapidconnect/bin/rapidconnect
+++ b/rapidconnect/bin/rapidconnect
@@ -1,11 +1,11 @@
 #!/usr/bin/env ruby
 
-ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../Gemfile', File.dirname(__FILE__))
-require 'rubygems'
-require 'bundler/setup'
+File.expand_path('..', File.dirname(__FILE__)).tap do |root|
+  ENV['BUNDLE_GEMFILE'] ||= File.join(root, 'Gemfile')
+  $LOAD_PATH.unshift(root)
+end
 
-require_relative '../app/rapid_connect'
-
+require 'init'
 require 'thor'
 
 class RapidConnectCLI < Thor


### PR DESCRIPTION
1.3.1 broke the command line tool:

```
/opt/rapidconnect/repository/rapidconnect/app/rapid_connect.rb:31:in `<class:RapidConnect>': uninitialized constant Rack::UTF8Sanitizer (NameError)
        from /opt/rapidconnect/repository/rapidconnect/app/rapid_connect.rb:20:in `<top (required)>'
        from /opt/rapidconnect/repository/rapidconnect/bin/rapidconnect:7:in `require_relative'
        from /opt/rapidconnect/repository/rapidconnect/bin/rapidconnect:7:in `<main>'
```