### PR TITLE
Fix organisation sort order

### DIFF
--- a/rapidconnect/app/rapid_connect.rb
+++ b/rapidconnect/app/rapid_connect.rb
@@ -589,6 +589,6 @@ class RapidConnect < Sinatra::Base
   # Organisation names via FR
   ##
   def load_organisations
-    JSON.parse(IO.read(settings.organisations))
+    JSON.parse(IO.read(settings.organisations)).sort_by(&:downcase)
   end
 end

--- a/rapidconnect/spec/rapid_connect_spec.rb
+++ b/rapidconnect/spec/rapid_connect_spec.rb
@@ -177,6 +177,14 @@ describe RapidConnect do
       expect(last_response.body).to contain('Service Registration')
     end
 
+    it 'sorts the organisations correctly' do
+      org_configuration = JSON.generate(['Org C', 'Org A', 'org B'])
+      allow(IO).to receive(:read).with(app.settings.organisations)
+        .and_return(org_configuration)
+      get '/registration', {}, 'rack.session' => { subject: @valid_subject }
+      expect(last_response.body).to match(/Org A.*org B.*Org C/m)
+    end
+
     context '/save' do
       before do
         allow(SecureRandom).to receive(:urlsafe_base64).and_return(identifier)


### PR DESCRIPTION
Previously this was relying on FR returning organisations in the correctly sorted order, which was doing a case-sensitive sort.