### PR TITLE
Make serviceunknown.erb more polite

### DIFF
--- a/rapidconnect/app/views/serviceunknown.erb
+++ b/rapidconnect/app/views/serviceunknown.erb
@@ -4,7 +4,8 @@
   </head>
   <body>
     <h2>Service Unknown</h2>
-    <p>We're really sorry but something has gone wrong.</p>
-    <p>Please try accessing your service again. If you continue to have problems please contact AAF support on <a href="mailto:support@aaf.edu.au">support@aaf.edu.au</a>.</p>
+    <p>Oops, we can't tell which service you were trying to access, so we can't log you in. Sorry about that.</p>
+    <p>Please try accessing the service again using the original link. If you arrived here from a bookmark, please remove the bookmark and try to access the service directly.</p>
+    <p>If you continue to have problems please contact AAF support on <a href="mailto:support@aaf.edu.au">support@aaf.edu.au</a>, and let us know which service you were trying to access.</p>
   </body>
 </html>


### PR DESCRIPTION
The error message was abrupt and confusing, and caused more support jobs than it should have.