### PR TITLE
Ensure user sessions contain all expected claims

### DIFF
--- a/rapidconnect/app/rapid_connect.rb
+++ b/rapidconnect/app/rapid_connect.rb
@@ -142,8 +142,12 @@ class RapidConnect < Sinatra::Base
         }
 
         session[:subject] = subject
-        @app_logger.info "Established session for #{subject[:cn]}(#{subject[:principal]})"
-        redirect target
+        if valid_subject?(subject)
+          @app_logger.info "Established session for #{subject[:cn]}(#{subject[:principal]})"
+          redirect target
+        else
+          redirect '/invalidsession'
+        end
       else
         redirect '/serviceunknown'
       end
@@ -162,6 +166,18 @@ class RapidConnect < Sinatra::Base
 
   get '/serviceunknown' do
     erb :serviceunknown
+  end
+
+  get '/invalidsession' do
+    erb :invalidsession
+  end
+
+  def valid_subject?(subject)
+    subject[:principal].present? &&
+      subject[:cn].present? &&
+      subject[:mail].present? &&
+      subject[:display_name].present? &&
+      subject[:scoped_affiliation].present?
   end
 
   ###

--- a/rapidconnect/app/views/invalidsession.erb
+++ b/rapidconnect/app/views/invalidsession.erb
@@ -1,12 +1,11 @@
 <html>
   <head>
-    <title>Service Unknown</title>
+    <title>Session Error</title>
   </head>
   <body>
     <h2>Session Error</h2>
     <p>Unfortunately some important details were not provided by your organisation when you logged in.</p>
-    <p>This is a backend technical issue and <strong>has not</strong> been caused by any action you've taken.</p>
-    <p>Unfortunately though, the error means you can't continue to at the moment. We're very sorry for the inconvenience.</p>
+    <p>This is a backend technical issue and <strong>has not</strong> been caused by any action you've taken. We're very sorry for the inconvenience.</p>
     <p>AAF support is available to assist in resolving this error in partnership with technical staff at your organisation. Please contact AAF support on <a href="mailto:support@aaf.edu.au">support@aaf.edu.au</a>, and provide a copy of the data shown below so we can assist as quickly as possible.</p>
 
     <pre>

--- a/rapidconnect/app/views/invalidsession.erb
+++ b/rapidconnect/app/views/invalidsession.erb
@@ -1,0 +1,26 @@
+<html>
+  <head>
+    <title>Service Unknown</title>
+  </head>
+  <body>
+    <h2>Session Error</h2>
+    <p>Unfortunately some important details were not provided by your organisation when you logged in.</p>
+    <p>This is a backend technical issue and <strong>has not</strong> been caused by any action you've taken.</p>
+    <p>Unfortunately though, the error means you can't continue to at the moment. We're very sorry for the inconvenience.</p>
+    <p>AAF support is available to assist in resolving this error in partnership with technical staff at your organisation. Please contact AAF support on <a href="mailto:support@aaf.edu.au">support@aaf.edu.au</a>, and provide a copy of the data shown below so we can assist as quickly as possible.</p>
+
+    <pre>
+----- begin halted session details ------
+
+Date: <%= Time.now %>
+Rapid Connect Version: <%= current_version %>
+
+Target: <%= session[:target] %>
+Subject: <%= session[:subject].inspect %>
+
+<%= Base64.encode64(env.inspect) %>
+
+----- end halted session details -----
+    </pre>
+  </body>
+</html>

--- a/rapidconnect/app/views/layout.erb
+++ b/rapidconnect/app/views/layout.erb
@@ -34,7 +34,7 @@
       <div class="container">
         <p>
           AAF Rapid Connect <strong>version <%= current_version %></strong>
-          <% if session[:subject] %>
+          <% if session[:subject] && session[:subject][:principal] && session[:subject][:cn] %>
             <br>
             Logged in as <em><%= session[:subject][:cn] %></em> ( <%=session[:subject][:principal]%> )
           <% end %>


### PR DESCRIPTION
Rapid Connect documentation lists the following attributes as being in
within the claim `https://aaf.edu.au/attributes` and describes them as
'SHOULD' exist.

1. cn
2. mail
3. displayname
4. edupersontargetedid
5. edupersonscopedaffiliation

To assist downstream developers this change catches sessions where
these attributes do not exist instead of passing them through to
connected applications.

Users who fall into this situation, it is not expected to occur often,
are provided with a request to contact AAF support and some debug data
to assist. AAF Support will then need to correct the issue as a tier 3
support activity with the backend IdP staff.

Closes #30.