### PR TITLE
Remove need for scoped_affilliation

### DIFF
--- a/rapidconnect/app/rapid_connect.rb
+++ b/rapidconnect/app/rapid_connect.rb
@@ -176,8 +176,7 @@ class RapidConnect < Sinatra::Base
     subject[:principal].present? &&
       subject[:cn].present? &&
       subject[:mail].present? &&
-      subject[:display_name].present? &&
-      subject[:scoped_affiliation].present?
+      subject[:display_name].present?
   end
 
   ###

--- a/rapidconnect/spec/rapid_connect_spec.rb
+++ b/rapidconnect/spec/rapid_connect_spec.rb
@@ -215,7 +215,10 @@ describe RapidConnect do
         let(:invalid_headers) do
           dup_headers_and_remove_exisiting('HTTP_AFFILIATION')
         end
-        include_examples 'halts invalid user session'
+        it 'does not halt session, continues' do
+          expect(last_response).to be_redirect
+          expect(last_response.location).not_to eq(invalid_session_target)
+        end
       end
     end
   end


### PR DESCRIPTION
This change needs to be reverted once #43 is ready to be satisfied.

Closes #42.