### PR TITLE
HTML syntax: properly escape special character

### DIFF
--- a/rapidconnect/app/views/administration/services/show.erb
+++ b/rapidconnect/app/views/administration/services/show.erb
@@ -55,7 +55,7 @@
         <div class="span12">
           <h3 class="muted">Endpoints <small>To be provided to application administrators</small></h3>
           <ol>
-            <li>Research & Scholarly Applications<br>
+            <li>Research &amp; Scholarly Applications<br>
               <% url = "https://#{settings.hostname}/jwt/authnrequest/#{@service.type}/#{@identifier}" %>
               <a href="<%= url %>"><%= url %></a>
             </li>


### PR DESCRIPTION
Hi,

I was editing our branding/customizations on the RapidConnect pages and syntax highlighting alerted me about this unescaped ampersand - so a tiny pull request.

Cheers,
Vlad

PS: Since the service types got introduced, the title no longer properly applies - but I did not want to burden the code with a set of if-statements (as it's displayed to admins only).  Or should I just drop the title and only list the endpoint?