### PR TITLE
Service show page: remove endpoint title

### DIFF
--- a/rapidconnect/app/views/administration/services/show.erb
+++ b/rapidconnect/app/views/administration/services/show.erb
@@ -55,7 +55,7 @@
         <div class="span12">
           <h3 class="muted">Endpoints <small>To be provided to application administrators</small></h3>
           <ol>
-            <li>Research &amp; Scholarly Applications<br>
+            <li>
               <% url = "https://#{settings.hostname}/jwt/authnrequest/#{@service.type}/#{@identifier}" %>
               <a href="<%= url %>"><%= url %></a>
             </li>


### PR DESCRIPTION
Since the service types got introduced, the URL title no longer properly applies.

Remove the endpoint title and list just the endpoint URL as discussed in #51.