### PR TITLE
Add ORCID attribute to attributes claim

### DIFF
--- a/rapidconnect/app/models/attributes_claim.rb
+++ b/rapidconnect/app/models/attributes_claim.rb
@@ -11,6 +11,7 @@ class AttributesClaim
       surname: subject[:surname], givenname: subject[:given_name],
       mail: subject[:mail], o: subject[:organization],
       auedupersonsharedtoken: subject[:shared_token],
+      edupersonorcid: subject[:orcid],
       edupersonscopedaffiliation: subject[:scoped_affiliation],
       edupersonprincipalname: subject[:principal_name],
       edupersontargetedid: retarget_id(iss, aud, subject)

--- a/rapidconnect/app/rapid_connect.rb
+++ b/rapidconnect/app/rapid_connect.rb
@@ -140,6 +140,7 @@ class RapidConnect < Sinatra::Base
           principal_name: env['HTTP_EPPN'],
           scoped_affiliation: env['HTTP_AFFILIATION'],
           o: env['HTTP_O'],
+          orcid: env['HTTP_EDUPERSONORCID'],
           shared_token: env['HTTP_AUEDUPERSONSHAREDTOKEN']
         }
 

--- a/rapidconnect/spec/factories.rb
+++ b/rapidconnect/spec/factories.rb
@@ -36,6 +36,7 @@ FactoryGirl.define do
     mail { "#{principal_name}@#{idp_domain}" }
     principal { "#{idp_entity_id}!#{sp_entity_id}!#{SecureRandom.base64(21)}" }
     scoped_affiliation { "member@#{idp_domain}" }
+    orcid { Faker::Base.bothify('http://orcid.org/0000-?000-####-####') }
     shared_token { SecureRandom.urlsafe_base64(24) }
 
     initialize_with { attributes.dup }

--- a/rapidconnect/spec/models/claims_set_spec.rb
+++ b/rapidconnect/spec/models/claims_set_spec.rb
@@ -89,7 +89,7 @@ RSpec.describe ClaimsSet do
     let(:type) { :research }
     let(:expected_attrs) do
       %i[cn mail displayname edupersontargetedid givenname surname
-         edupersonscopedaffiliation edupersonprincipalname]
+         edupersonorcid edupersonscopedaffiliation edupersonprincipalname]
     end
 
     it_behaves_like 'a jwt claims set'
@@ -100,7 +100,7 @@ RSpec.describe ClaimsSet do
     let(:type) { :auresearch }
     let(:expected_attrs) do
       %i[cn mail displayname edupersontargetedid givenname surname
-         edupersonscopedaffiliation edupersonprincipalname
+         edupersonscopedaffiliation edupersonprincipalname edupersonorcid
          auedupersonsharedtoken]
     end
 

--- a/rapidconnect/spec/rapid_connect_spec.rb
+++ b/rapidconnect/spec/rapid_connect_spec.rb
@@ -33,6 +33,7 @@ describe RapidConnect do
       'HTTP_MAIL' => 'testuser@example.com',
       'HTTP_EPPN' => 'tuser1@example.com',
       'HTTP_AFFILIATION' => 'staff@example.com',
+      'HTTP_EDUPERSONORCID' => 'http://orcid.org/0000-0002-1825-0097',
       'HTTP_AUEDUPERSONSHAREDTOKEN' => 'shared_token'
     }
 
@@ -45,6 +46,7 @@ describe RapidConnect do
       mail: @valid_shibboleth_headers['HTTP_MAIL'],
       principal_name: @valid_shibboleth_headers['HTTP_EPPN'],
       scoped_affiliation: @valid_shibboleth_headers['HTTP_AFFILIATION'],
+      orcid: @valid_shibboleth_headers['HTTP_EDUPERSONORCID'],
       shared_token: @valid_shibboleth_headers['HTTP_AUEDUPERSONSHAREDTOKEN']
     }
 
@@ -149,6 +151,7 @@ describe RapidConnect do
       expect(session[:subject][:mail]).to eq(@valid_shibboleth_headers['HTTP_MAIL'])
       expect(session[:subject][:principal_name]).to eq(@valid_shibboleth_headers['HTTP_EPPN'])
       expect(session[:subject][:scoped_affiliation]).to eq(@valid_shibboleth_headers['HTTP_AFFILIATION'])
+      expect(session[:subject][:orcid]).to eq(@valid_shibboleth_headers['HTTP_EDUPERSONORCID'])
       expect(session[:subject][:shared_token]).to eq(@valid_shibboleth_headers['HTTP_AUEDUPERSONSHAREDTOKEN'])
     end
 
@@ -877,7 +880,7 @@ describe RapidConnect do
       let(:type) { 'research' }
       let(:attrs) do
         %w[cn mail displayname givenname surname edupersontargetedid
-           edupersonscopedaffiliation edupersonprincipalname]
+           edupersonorcid edupersonscopedaffiliation edupersonprincipalname]
       end
 
       include_context 'a research service type'
@@ -887,7 +890,7 @@ describe RapidConnect do
       let(:type) { 'auresearch' }
       let(:attrs) do
         %w[cn mail displayname givenname surname edupersontargetedid
-           edupersonscopedaffiliation edupersonprincipalname
+           edupersonscopedaffiliation edupersonprincipalname edupersonorcid
            auedupersonsharedtoken]
       end
 


### PR DESCRIPTION
Propagates the eduPersonOrcid attribute value through and releases as `edupersonorcid` in the `https://aaf.edu.au/attributes` claim.

I was able to test this by adding the following Apache config in development:

```apache
RequestHeader add eduPersonOrcid http://orcid.org/0000-0002-1825-0097
```

The attribute was added to the JWS as expected.

Needs #63 to be merged before the diff here makes any sense, or you can just look at b440d11.