### PR TITLE
Patch for CVE-2018-14404 (Nokigiri)

### DIFF
--- a/rapidconnect/Gemfile
+++ b/rapidconnect/Gemfile
@@ -31,7 +31,7 @@ group :test, :development do
   gem 'factory_bot'
   gem 'faker'
   gem 'fakeredis'
-  gem 'nokogiri', '1.8.2'
+  gem 'nokogiri', '1.10.3'
   gem 'rspec'
   gem 'rubocop'
   gem 'simplecov'

--- a/rapidconnect/Gemfile.lock
+++ b/rapidconnect/Gemfile.lock
@@ -82,13 +82,13 @@ GEM
       mini_mime (>= 0.1.1)
     method_source (0.9.0)
     mini_mime (1.0.1)
-    mini_portile2 (2.3.0)
+    mini_portile2 (2.4.0)
     minitest (5.11.3)
     multi_json (1.13.1)
     mustermann (1.0.3)
     nenv (0.3.0)
-    nokogiri (1.8.2)
-      mini_portile2 (~> 2.3.0)
+    nokogiri (1.10.3)
+      mini_portile2 (~> 2.4.0)
     notiffany (0.1.1)
       nenv (~> 0.1)
       shellany (~> 0.0)
@@ -199,7 +199,7 @@ DEPENDENCIES
   guard-rubocop
   json-jwt
   mail
-  nokogiri (= 1.8.2)
+  nokogiri (= 1.10.3)
   rack-flash3
   rack-utf8_sanitizer
   rake


### PR DESCRIPTION
A NULL pointer dereference vulnerability exists in the xpath.c:xmlXPathCompOpEval() function of libxml2 through 2.9.8 when parsing an invalid XPath expression in the XPATH_OP_AND or XPATH_OP_OR case. Applications processing untrusted XSL format inputs with the use of the libxml2
library may be vulnerable to a denial of service attackdue to a crash of the application.

Notified by GitHub security alerts, no linked AAF issue.