### PR TITLE
SubjectAttrs: Fix mismatched o/organisation subject attribute name

### DIFF
--- a/rapidconnect/app/rapid_connect.rb
+++ b/rapidconnect/app/rapid_connect.rb
@@ -139,7 +139,7 @@ class RapidConnect < Sinatra::Base
           mail: env['HTTP_MAIL'],
           principal_name: env['HTTP_EPPN'],
           scoped_affiliation: env['HTTP_AFFILIATION'],
-          o: env['HTTP_O'],
+          organization: env['HTTP_O'],
           orcid: env['HTTP_EDUPERSONORCID'],
           shared_token: env['HTTP_AUEDUPERSONSHAREDTOKEN']
         }


### PR DESCRIPTION
Hi @bradleybeddoes , I found a minor nit when looking at passing the org name through RapidConnect:

rapid_connect.rb login handler (L142) was storing the attribute as "o",
while attributes_claim.rb L12 was expecting it to be stored as
"organization".

Make both use "organization" (as this is also what the spec code uses).

This is a trivial fix (and all checks pass), but it opens a slightly bigger question: would it be OK to also pass the organisation name (`o` attribute) as part of the attribute set?

I see that RapidConnect receives it all fine (and uses it with Freshdesk and Zendesk), but explicitly filters it out for `research` / `auresearch` attribute sets:
https://github.com/REANNZ/rapidconnect/blob/master/rapidconnect/app/models/claims_set.rb#L16

Was there a specific reason for this filtering?  Given there's already information about the institution passed in eduPersonScopedAffiliation, I would not consider the human readable organization name in any way sensitive.  And one of our members has asked for it....

Would you be OK with merging this fix and a change allowing `o` through at least for `auresearch`?   What are your thoughts on this?

Cheers,
Vlad
