### PR TITLE
frdatacollabor: update dependencies - keep up to date with RapidConnect

### DIFF
--- a/frdatacollator/Gemfile.lock
+++ b/frdatacollator/Gemfile.lock
@@ -3,7 +3,7 @@ GEM
   specs:
     addressable (2.5.2)
       public_suffix (>= 2.0.2, < 4.0)
-    public_suffix (3.0.0)
+    public_suffix (3.0.3)
 
 PLATFORMS
   ruby


### PR DESCRIPTION
Keep frdatacollabor dependencies in line with main rapidconnect dependencies - public_suffix in frdatacollator/Gemfile.lock was somehow missed in e103aa6e...