### PR TITLE
frdatacollator: make target file configurable

### DIFF
--- a/frdatacollator/collator.rb
+++ b/frdatacollator/collator.rb
@@ -24,6 +24,7 @@ end
 
 @config = YAML.load_file('config.yml')
 
+target_file = @config['target_file'] || '/tmp/fr_org_names.json.new'
 org_names = []
 fr_response = secure_server_request Addressable::URI.encode @config['org_api_endpoint']
 fr_json = JSON.parse fr_response
@@ -33,5 +34,5 @@ fr_json["organizations"].each { |org|
   org_names << fr_org_json['organization']['displayName']
 }
 
-File.open('/tmp/fr_org_names.json.new', 'w') {|f| f.write( JSON.generate org_names.sort! ) }
+File.open(target_file, 'w') {|f| f.write( JSON.generate org_names.sort! ) }
 

--- a/frdatacollator/config.yml.dist
+++ b/frdatacollator/config.yml.dist
@@ -1,2 +1,3 @@
 server: 'manager.test.example.edu.au'
 org_api_endpoint: '/federationregistry/api/v1/organizations'
+target_file: '/tmp/fr_org_names.json.new'


### PR DESCRIPTION

Hi @bradleybeddoes ,

I've added an option for frdatacollator to read the target file name from the (already existing) config file.  If the target file name is not specified in the config file, it defaults to the original value, `/tmp/fr_org_names.json.new` - so should have no impact on you.

Would you be happy to merge this?

Cheers,
Vlad
