### PR TITLE
Config: fix rubocop violations in config/unicorn.rb.dist

### DIFF
--- a/rapidconnect/config/unicorn.rb.dist
+++ b/rapidconnect/config/unicorn.rb.dist
@@ -1,7 +1,9 @@
-listen "127.0.0.1:8080"
+# frozen_string_literal: true
+
+listen '127.0.0.1:8080'
 worker_processes 5
 preload_app true
 
-pid "tmp/unicorn.pid"
-stderr_path "logs/unicorn-stderr.log"
-stdout_path "logs/unicorn-stdout.log"
+pid 'tmp/unicorn.pid'
+stderr_path 'logs/unicorn-stderr.log'
+stdout_path 'logs/unicorn-stdout.log'


### PR DESCRIPTION
... because these upset Rubocop in environments where config/unicorn.rb.dist is copied to config/unicorn.rb.